### PR TITLE
Defer loading of bootstrap.json file until use #88

### DIFF
--- a/cmd/device-agent-helper/main_darwin.go
+++ b/cmd/device-agent-helper/main_darwin.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/nais/device/pkg/bootstrap"
 	"github.com/nais/device/pkg/logger"
 	"io/ioutil"
 	"os/exec"
@@ -70,12 +71,12 @@ func setupRoutes(ctx context.Context, cidrs []string, interfaceName string) erro
 	return nil
 }
 
-func setupInterface(ctx context.Context, cfg Config) error {
+func setupInterface(ctx context.Context, cfg Config, bootstrapConfig *bootstrap.Config) error {
 	if interfaceExists(ctx, cfg) {
 		return nil
 	}
 
-	ip := cfg.BootstrapConfig.DeviceIP
+	ip := bootstrapConfig.DeviceIP
 	commands := [][]string{
 		{WireGuardGoBinary, cfg.Interface},
 		{"ifconfig", cfg.Interface, "inet", ip + "/21", ip, "add"},

--- a/cmd/device-agent-helper/main_linux.go
+++ b/cmd/device-agent-helper/main_linux.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/nais/device/pkg/bootstrap"
 	"github.com/nais/device/pkg/logger"
 	"io/ioutil"
 	"os/exec"
@@ -71,7 +72,7 @@ func setupRoutes(ctx context.Context, cidrs []string, interfaceName string) erro
 	return nil
 }
 
-func setupInterface(ctx context.Context, cfg Config) error {
+func setupInterface(ctx context.Context, cfg Config, bootstrapConfig *bootstrap.Config) error {
 	if err := exec.Command("ip", "link", "del", "wg0").Run(); err != nil {
 		log.Infof("pre-deleting WireGuard interface (ok if this fails): %v", err)
 	}
@@ -79,7 +80,7 @@ func setupInterface(ctx context.Context, cfg Config) error {
 	commands := [][]string{
 		{"ip", "link", "add", "dev", "wg0", "type", "wireguard"},
 		{"ip", "link", "set", "mtu", "1360", "up", "dev", "wg0"},
-		{"ip", "address", "add", "dev", "wg0", cfg.BootstrapConfig.DeviceIP + "/21"},
+		{"ip", "address", "add", "dev", "wg0", bootstrapConfig.DeviceIP + "/21"},
 	}
 
 	return runCommands(ctx, commands)

--- a/cmd/device-agent-helper/main_windows.go
+++ b/cmd/device-agent-helper/main_windows.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/nais/device/pkg/bootstrap"
 	"github.com/nais/device/pkg/logger"
 	log "github.com/sirupsen/logrus"
 	flag "github.com/spf13/pflag"
@@ -71,7 +72,7 @@ func interfaceExists(ctx context.Context, cfg Config) bool {
 	}
 }
 
-func setupInterface(ctx context.Context, cfg Config) error {
+func setupInterface(ctx context.Context, cfg Config, bootstrapConfig *bootstrap.Config) error {
 	if interfaceExists(ctx, cfg) {
 		return nil
 	}


### PR DESCRIPTION
This enables the device-agent to create the file before the device-agent-helper tries to load it.