### PR TITLE
Notify Slack on incomplete Kolide checks

### DIFF
--- a/.github/workflows/check-severity.yml
+++ b/.github/workflows/check-severity.yml
@@ -26,6 +26,14 @@ jobs:
         run: composer install --prefer-dist --no-progress --no-suggest --no-ansi -o --no-dev
 
       - name: Validate Kolide checks
+        id: validate-checks
         run: php device-health-checker.php kolide:validate-checks -t $KOLIDE_API_TOKEN
         env:
           KOLIDE_API_TOKEN: ${{ secrets.KOLIDE_API_TOKEN }}
+
+      - name: Alert the Slack channel if the validation failed
+        if: failure()
+        run: php notify-slack.php
+        env:
+          INCOMPLETE_CHECKS: ${{ steps.validate-checks.outputs.incomplete-checks }}
+          SLACK_WEBHOOK: ${{ secrets.KOLIDE_CHECKS_VALIDATION_SLACK_WEBHOOK }}

--- a/device-health-checker/README.md
+++ b/device-health-checker/README.md
@@ -32,6 +32,8 @@ This command will validate that there exists a criticality level for all Kolide 
 
     ./device-health-checker.phar kolide:validate-checks -t $KOLIDE_API_TOKEN
 
+This command is run as a scheduled workflow in this repository, and if the command finds checks with missing tags it will send a message to the `#nais-device-alerts` channel. This is done using a webhook that is owned by the `Kolide checks validation` Slack app installed on the NAV IT workspace.
+
 #### Command options
 
 ##### `-t/--kolide-api-token <token>` (required)

--- a/device-health-checker/notify-slack.php
+++ b/device-health-checker/notify-slack.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+function fail(string $message) : void {
+    echo trim($message) . PHP_EOL;
+    exit(1);
+}
+
+foreach (['INCOMPLETE_CHECKS', 'SLACK_WEBHOOK'] as $requiredEnvVar) {
+    if (empty(getenv($requiredEnvVar))) {
+        fail(sprintf('Missing required environment variable: %s', $requiredEnvVar));
+    }
+}
+
+$incompleteChecks = json_decode(getenv('INCOMPLETE_CHECKS'), true);
+
+if (json_last_error() !== JSON_ERROR_NONE) {
+    fail(sprintf('Unable to decode JSON: %s', json_last_error_msg()));
+}
+
+$c = curl_init();
+
+curl_setopt($c, CURLOPT_URL, getenv('SLACK_WEBHOOK'));
+curl_setopt($c, CURLOPT_HTTPHEADER, ['Content-Type: application/json']);
+curl_setopt($c, CURLOPT_POST, 1);
+curl_setopt($c, CURLOPT_POSTFIELDS, json_encode([
+    'blocks' => [
+        [
+            'type' => 'section',
+            'text' => [
+                'type' => 'mrkdwn',
+                'text' => 'The following <https://k2.kolide.com/1401/checks/active?tags%5B%5D=untagged|Kolide checks> are missing tags:',
+            ],
+        ],
+        [
+            'type' => 'divider',
+        ],
+        ...array_map(function(array $c) : array {
+            return [
+                'type' => 'section',
+			    'text' => [
+                    'type' => 'mrkdwn',
+                    'text' => sprintf(
+                        "*<https://k2.kolide.com/1401/checks/%d|%s>* (%d failure%s)\n%s\n\n_Compatibility_: %s\n_Topics_: %s",
+                        $c['id'],
+                        $c['name'],
+                        $c['failing_device_count'],
+                        1 !== $c['failing_device_count'] ? 's' : '',
+                        $c['description'],
+                        implode(', ', $c['compatibility']) ?: 'n/a',
+                        implode(', ', $c['topics']) ?: 'n/a',
+                    ),
+                ],
+            ];
+        }, $incompleteChecks),
+    ],
+]));
+
+curl_exec($c);

--- a/device-health-checker/src/Command/ValidateKolideChecksSeverity.php
+++ b/device-health-checker/src/Command/ValidateKolideChecksSeverity.php
@@ -58,6 +58,9 @@ class ValidateKolideChecksSeverity extends BaseCommand {
                 ),
                 $incompleteChecks
             ));
+
+            $output->writeln(sprintf('::set-output name=incomplete-checks::%s', json_encode($incompleteChecks)));
+
             return Command::FAILURE;
         }
 

--- a/device-health-checker/tests/Command/ValidateKolideChecksSeverityTest.php
+++ b/device-health-checker/tests/Command/ValidateKolideChecksSeverityTest.php
@@ -82,6 +82,7 @@ class ValidateKolideChecksSeverityTest extends TestCase {
 The following Kolide checks are missing a severity tag:
 some other name (ID: 2, https://k2.kolide.com/1401/checks/2): some other description
 some third name (ID: 3, https://k2.kolide.com/1401/checks/3): some third description
+::set-output name=incomplete-checks::[{"id":2,"name":"some other name","description":"some other description","tags":["WINDOWS"]},{"id":3,"name":"some third name","description":"some third description","tags":["LINUX"]}]
 DISPLAY;
 
         $this->assertSame(1, $exitCode, 'Expected exit code to be 1');


### PR DESCRIPTION
The scheduled workflow that checks for Kolide checks with missing tags should nag to the `#nais-device-alerts` channel on Slack. This PR adds this behaviour.

The `KOLIDE_CHECKS_VALIDATION_SLACK_WEBHOOK` secret that has been added to the repo currently points to a test-channel, and I will update the secret once I have verified that the message looks as expected.

~Todo before merging this PR: Document the scheduled workflow along with the Slack App used for this purpose in the README.~ 483e16c84c55e695781aacf5727e37d1d5fa9591