### PR TITLE
feature: Turn on iptables rule logging in dmesg for gateways

### DIFF
--- a/ansible/roles/gateway/tasks/main.yml
+++ b/ansible/roles/gateway/tasks/main.yml
@@ -24,7 +24,7 @@
   get_url:
     dest: /opt/nais-device/bin/gateway-agent
     force: yes
-    url: https://github.com/nais/device/releases/download/2020-07-09-8f8ee2c/gateway-agent
+    url: https://github.com/nais/device/releases/download/2020-09-18-790a08b/gateway-agent
     backup: yes
     mode: 0755
   notify:


### PR DESCRIPTION
This commit just deploys new version to all gateways with Ansible.