### PR TITLE
try to prevent blinking cursor by removing text format 5

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,11 +5,11 @@ err='no error'
 latest_tag=''
 
 ok() {
-  echo -e "..[\033[38;5;82mok\033[0;5;82m]"
+  echo -e "..[\033[32mok\033[0m]"
 }
 
 fail() {
-  echo -e "[\033[31;5;82mfail\033[0;5;82m]"
+  echo -e "[\033[31mfail\033[0m]"
   echo $err
   exit 1
 }


### PR DESCRIPTION
An attempt to fix https://github.com/nais/device/issues/147

Using standard ANSI-colours and removing text format=5, which implies blinking, ref. https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters

only tested on osx