### PR TITLE
Build debian package

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -6,6 +6,7 @@ on:
       - 'go.mod'
       - '**.go'
       - '.github/workflows/master.yml'
+      - 'packaging/**'
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -118,6 +119,31 @@ jobs:
           path: bin/windows/naisdevice.msi
           if-no-files-found: error
 
+  build-linux:
+    needs:
+      - set-version
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: download linux binaries
+        uses: actions/download-artifact@v2
+        with:
+          name: linux-client
+          path: bin/linux-client
+      - name: create debian package
+        run: |
+          sudo apt update
+          sudo apt install --yes build-essential ruby ruby-dev rubygems
+          sudo gem install --no-document fpm
+          make deb VERSION=${{ needs.set-version.outputs.version }}
+      - name: upload debian package
+        uses: actions/upload-artifact@v2
+        with:
+          name: deb
+          path: naisdevice*.deb
+          if-no-files-found: error
+
   release:
     if: ${{ github.ref == 'refs/heads/master' }}
     needs:
@@ -126,6 +152,7 @@ jobs:
       - build
       - build-macos
       - build-windows
+      - build-linux
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -172,6 +199,7 @@ jobs:
           asset_path: ./bin/controlplane/prometheus-agent
           asset_name: prometheus-agent
           asset_content_type: application/octet-stream
+
       - name: download windows installer
         uses: actions/download-artifact@v2
         with:
@@ -195,5 +223,17 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./naisdevice.pkg
           asset_name: naisdevice.pkg
+          asset_content_type: application/octet-stream
+
+      - name: download deb
+        uses: actions/download-artifact@v2
+        with:
+          name: deb
+      - name: upload debian package to release
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./naisdevice*.deb
+          asset_name: naisdevice.deb
           asset_content_type: application/octet-stream
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ cmd/device-agent/main_windows.syso
 cmd/device-agent-helper/main_windows.syso
 packaging/windows/obj
 /device-agent.log
+naisdevice*.deb

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ wireguard-tools-*
 cmd/device-agent/main_windows.syso
 cmd/device-agent-helper/main_windows.syso
 packaging/windows/obj
-/device-agent.log
+packaging/linux/icons
+device-agent.log
 naisdevice*.deb

--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,10 @@ pkg: app
 	rm -rf ./pkgtemp ./naisdevice.app
 	# gon --log-level=debug packaging/macos/gon-pkg.json
 
+# Run by GitHub actions on linux
+deb: linux-client
+	./packaging/linux/build-deb $(VERSION)
+
 clean:
 	rm -rf wireguard-go-*
 	rm -rf wireguard-tools-*

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ bin/linux-client/device-agent-helper:
 	GOOS=linux GOARCH=amd64 go build -o bin/linux-client/device-agent-helper ./cmd/device-agent-helper
 bin/linux-client/device-agent: cmd/device-agent/icons.go
 	mkdir -p ./bin/linux-client
-	GOOS=linux GOARCH=amd64 go build -o bin/linux-client/device-agent ./cmd/device-agent
+	GOOS=linux GOARCH=amd64 go build -o bin/linux-client/device-agent -ldflags "-s $(LDFLAGS)" ./cmd/device-agent
 
 # Run by GitHub actions on macos
 macos-client: cmd/device-agent/icons.go

--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,13 @@ controlplane:
 	GOOS=linux GOARCH=amd64 go build -o bin/controlplane/prometheus-agent ./cmd/prometheus-agent
 
 # Run by GitHub actions on linux
-linux-client:
+linux-client: bin/linux-client/device-agent bin/linux-client/device-agent-helper
+bin/linux-client/device-agent-helper:
+	mkdir -p ./bin/linux-client
+	GOOS=linux GOARCH=amd64 go build -o bin/linux-client/device-agent-helper ./cmd/device-agent-helper
+bin/linux-client/device-agent:
 	mkdir -p ./bin/linux-client
 	GOOS=linux GOARCH=amd64 go build -o bin/linux-client/device-agent ./cmd/device-agent
-	GOOS=linux GOARCH=amd64 go build -o bin/linux-client/device-agent-helper ./cmd/device-agent-helper
 
 # Run by GitHub actions on macos
 macos-client:

--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,11 @@ dev-apiserver: local-postgres local-apiserver stop-postgres
 integration-test: stop-postgres-test run-postgres-test run-integration-test stop-postgres-test
 clients: linux-client macos-client windows-client
 
-# Before building linux-client, these are needed
+# Before building linux-client and debian package, these are needed
 linux-init:
 	sudo apt update
-	sudo apt install build-essential libgtk-3-dev libappindicator3-dev
+	sudo apt install build-essential libgtk-3-dev libappindicator3-dev ruby ruby-dev rubygems
+	sudo gem install --no-document fpm
 
 # Run by GitHub actions
 controlplane:

--- a/cmd/device-agent-helper/main_linux.go
+++ b/cmd/device-agent-helper/main_linux.go
@@ -14,8 +14,7 @@ import (
 )
 
 const (
-	WireGuardBinary   = "/usr/bin/wg"
-	ProductSerialPath = "/sys/devices/virtual/dmi/id/product_serial"
+	WireGuardBinary = "/usr/bin/wg"
 )
 
 func prerequisites() error {
@@ -27,10 +26,6 @@ func prerequisites() error {
 
 func platformInit(cfg *Config) {
 	logger.SetupDeviceLogger(cfg.LogLevel, filepath.Join("/", "var", "log", "device-agent-helper.log"))
-	if err := extractProductSerial(ProductSerialPath); err != nil {
-		log.Error(err)
-	}
-
 }
 
 func syncConf(cfg Config, ctx context.Context) error {
@@ -95,20 +90,6 @@ func teardownInterface(ctx context.Context, cfg Config) {
 	if err := cmd.Run(); err != nil {
 		log.Errorf("Tearing down interface: %v", err)
 	}
-}
-
-func extractProductSerial(cfgpath string) error {
-	target := filepath.Join(cfg.ConfigPath, "product_serial")
-	serialBytes, err := ioutil.ReadFile(ProductSerialPath)
-	if err != nil {
-		return fmt.Errorf("reading file: %w", err)
-	}
-	if err := ioutil.WriteFile(target, serialBytes, 0644); err != nil {
-		return fmt.Errorf("Writing product serial to disk: %v", err)
-	} else {
-		log.Debugf("Successfully wrote product serial to: %v", target)
-	}
-	return nil
 }
 
 func uninstallService()         {}

--- a/packaging/linux/build-deb
+++ b/packaging/linux/build-deb
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+set -o errexit
+set -o pipefail
+set -o nounset
+
 rm -f ./naisdevice*.deb
 
 fpm \
@@ -17,4 +21,6 @@ fpm \
     --after-install packaging/linux/postinstall \
     --deb-systemd packaging/linux/device-agent-helper.service \
     bin/linux-client/device-agent-helper=/usr/sbin/device-agent-helper \
-    bin/linux-client/device-agent=/usr/bin/naisdevice
+    bin/linux-client/device-agent=/usr/bin/naisdevice \
+    packaging/linux/naisdevice.desktop=/usr/share/applications/ \
+    packaging/linux/icons/=/usr/share/icons/hicolor/

--- a/packaging/linux/build-deb
+++ b/packaging/linux/build-deb
@@ -2,7 +2,7 @@
 
 rm -f ./naisdevice*.deb
 
-docker run -v "$(pwd):/src/" cdrx/fpm-ubuntu fpm \
+fpm \
     --verbose \
     --output-type deb \
     --input-type dir \

--- a/packaging/linux/build-deb
+++ b/packaging/linux/build-deb
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+rm -f ./naisdevice*.deb
+
+docker run -v "$(pwd):/src/" cdrx/fpm-ubuntu fpm \
+    --verbose \
+    --output-type deb \
+    --input-type dir \
+    --name naisdevice \
+    --version "${1:-Unknown}" \
+    --vendor "NAV / Platformteamet" \
+    --maintainer "NAV / Platformteamet" \
+    --description "naisdevice is a mechanism enabling NAVs developers to connect to internal resources in a secure and friendly manner." \
+    --url https://doc.nais.io/device \
+    --depends jq \
+    --depends sed \
+    --after-install packaging/linux/postinstall \
+    --deb-systemd packaging/linux/device-agent-helper.service \
+    bin/linux-client/device-agent-helper=/usr/sbin/device-agent-helper \
+    bin/linux-client/device-agent=/usr/bin/naisdevice

--- a/packaging/linux/device-agent-helper.service
+++ b/packaging/linux/device-agent-helper.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Naisdevice agent helper
+Documentation=https://doc.nais.io/device
+
+[Service]
+ExecStart=/usr/sbin/device-agent-helper --config-dir @@CONFIG_DIR@@
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/linux/naisdevice.desktop
+++ b/packaging/linux/naisdevice.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Name=Naisdevice
+Exec=naisdevice
+Terminal=false
+Type=Application
+Icon=naisdevice
+Categories=Network

--- a/packaging/linux/postinstall
+++ b/packaging/linux/postinstall
@@ -7,3 +7,5 @@ config_dir="${home}/.config/naisdevice/"
 unit_file=/lib/systemd/system/device-agent-helper.service
 
 sed -i "s%@@CONFIG_DIR@@%${config_dir}%" "${unit_file}"
+
+cp /sys/devices/virtual/dmi/id/product_serial "${config_dir}"

--- a/packaging/linux/postinstall
+++ b/packaging/linux/postinstall
@@ -6,6 +6,10 @@ home=$(getent passwd "${user}" | cut -d: -f 6)
 config_dir="${home}/.config/naisdevice/"
 unit_file=/lib/systemd/system/device-agent-helper.service
 
+mkdir -p "${config_dir}"
+
 sed -i "s%@@CONFIG_DIR@@%${config_dir}%" "${unit_file}"
 
 cp /sys/devices/virtual/dmi/id/product_serial "${config_dir}"
+
+chown -R "${user}:" "${config_dir}"

--- a/packaging/linux/postinstall
+++ b/packaging/linux/postinstall
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+user=$(loginctl list-users --output json | jq -r ".[0].user")
+home=$(getent passwd "${user}" | cut -d: -f 6)
+
+config_dir="${home}/.config/naisdevice/"
+unit_file=/lib/systemd/system/device-agent-helper.service
+
+sed -i "s%@@CONFIG_DIR@@%${config_dir}%" "${unit_file}"


### PR DESCRIPTION
Builds a debian package using fpm (which can be used to create rpm package later), and uploads it as a release asset same way as the macos pkg and the windows msi files.

One choice that might be controversal:
I've named the main binary `naisdevice` instead of `device-agent` once it is installed. This is because this is the command users need to execute to start naisdevice, and it just makes more sense to name it like that.

When this is out, we have a working debian package, but I'm going to continue by adding needed config files to get naisdevice into the Applications menu.
