### PR TITLE
Enable Retina display support

### DIFF
--- a/packaging/macos/Info.plist.tpl
+++ b/packaging/macos/Info.plist.tpl
@@ -20,5 +20,7 @@
 	<string>1</string>
 	<key>LSUIElement</key>
 	<true/>
+	<key>NSHighResolutionCapable</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Dette slår på støtte for retina display og gjør at teksten er klar og tydelig på MacBook Pro-er osv.

<img width="344" alt="Skjermbilde 2021-05-06 kl  21 29 17" src="https://user-images.githubusercontent.com/5680727/117354836-1e423800-aeb2-11eb-9b00-de4f70b403b1.png">
