### PR TITLE
Make sure to kill all the things in postinstall

### DIFF
--- a/packaging/linux/postinstall
+++ b/packaging/linux/postinstall
@@ -39,6 +39,7 @@ home=$(getent passwd "${user}" | cut -d: -f 6)
 config_dir="${home}/.config/naisdevice/"
 log_dir="${config_dir}/logs"
 unit_file=/lib/systemd/system/naisdevice-helper.service
+daemon_name=$(basename ${unit_file})
 
 for directory in "$config_dir" "$log_dir"; do
 	mkdir -p "$directory"
@@ -52,8 +53,7 @@ cp /sys/devices/virtual/dmi/id/product_serial "${config_dir}"
 chown -R "${user}:" "${config_dir}"
 
 set +e
-systemctl is-active --quiet device-agent-helper.service \
-	&& systemctl stop device-agent-helper.service
+systemctl is-active --quiet "${daemon_name}" \
+	&& systemctl stop "${daemon_name}"
 
-killall naisdevice-systray || true
-killall naisdevice-agent || true
+killall --regexp "naisdevice.*" || true

--- a/packaging/macos/postinstall
+++ b/packaging/macos/postinstall
@@ -49,5 +49,4 @@ launchctl load "$destination"
 
 echo "Installed service $daemon_name"
 
-killall naisdevice-agent || true
-killall naisdevice-systray || true
+killall -m "naisdevice.*" || true


### PR DESCRIPTION
On linux, the service has not been named `device-agent-helper.service` for quite some time, and the process is not `naisdevice-systray`, it is `naisdevice`.

Changes the `killall` at the end of the postinstall scripts (both linux and macos) to use regex matching instead of listing every process to kill.