### PR TITLE
Support Dark-mode on macOS

### DIFF
--- a/pkg/systray/gui.go
+++ b/pkg/systray/gui.go
@@ -278,7 +278,7 @@ func (gui *Gui) handleAgentStatus(agentStatus *pb.AgentStatus) {
 
 func (gui *Gui) applyDisconnectedIcon() {
 	if gui.Config.BlackAndWhiteIcons {
-		systray.SetIcon(NaisLogoBwDisconnected)
+		systray.SetTemplateIcon(NaisLogoBwDisconnected, NaisLogoBwDisconnected)
 	} else {
 		systray.SetIcon(NaisLogoRed)
 	}
@@ -289,7 +289,7 @@ func (gui *Gui) updateIcons() {
 		gui.applyDisconnectedIcon()
 	} else if gui.AgentStatus.GetConnectionState() == pb.AgentState_Connected {
 		if gui.Config.BlackAndWhiteIcons {
-			systray.SetIcon(NaisLogoBwConnected)
+			systray.SetTemplateIcon(NaisLogoBwConnected, NaisLogoBwConnected)
 		} else {
 			systray.SetIcon(NaisLogoGreen)
 		}


### PR DESCRIPTION
Before light:

<img width="34" alt="Skjermbilde 2021-06-28 kl  13 46 38" src="https://user-images.githubusercontent.com/36937807/123631641-477aa700-d817-11eb-8e34-fedbd40c2c6f.png">

After light:

<img width="51" alt="Skjermbilde 2021-06-28 kl  13 42 27" src="https://user-images.githubusercontent.com/36937807/123631670-4e091e80-d817-11eb-87ce-1871f5189d8b.png">

Before dark:

<img width="32" alt="Skjermbilde 2021-06-28 kl  13 47 16" src="https://user-images.githubusercontent.com/36937807/123631720-5d886780-d817-11eb-9181-be200abf8be0.png">

After dark:
<img width="30" alt="Skjermbilde 2021-06-28 kl  13 42 35" src="https://user-images.githubusercontent.com/36937807/123631766-68db9300-d817-11eb-8bd8-60957031e86d.png">

As per. https://developer.apple.com/design/human-interface-guidelines/macos/extensions/menu-bar-extras/ it is recommended for menu bar extras to use template icons

