### PR TITLE
refactor: make helper independent of users config dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ bin
 wireguard-go-*
 wireguard-tools-*
 cmd/device-agent/main_windows.syso
-cmd/device-agent-helper/main_windows.syso
+cmd/helper/main_windows.syso
 packaging/windows/obj
 packaging/linux/icons
 device-agent.log

--- a/Makefile
+++ b/Makefile
@@ -33,24 +33,24 @@ linux-client: cmd/device-agent/icons.go
 	mkdir -p ./bin/linux-client
 	GOOS=linux GOARCH=amd64 go build -o bin/linux-client/naisdevice-systray -ldflags "-s $(LDFLAGS)" ./cmd/systray
 	GOOS=linux GOARCH=amd64 go build -o bin/linux-client/naisdevice-agent -ldflags "-s $(LDFLAGS)" ./cmd/device-agent
-	GOOS=linux GOARCH=amd64 go build -o bin/linux-client/naisdevice-helper -ldflags "-s $(LDFLAGS)" ./cmd/device-agent-helper
+	GOOS=linux GOARCH=amd64 go build -o bin/linux-client/naisdevice-helper -ldflags "-s $(LDFLAGS)" ./cmd/helper
 
 # Run by GitHub actions on macos
 macos-client: cmd/device-agent/icons.go
 	mkdir -p ./bin/macos-client
 	GOOS=darwin GOARCH=amd64 go build -o bin/macos-client/naisdevice-agent -ldflags "-s $(LDFLAGS)" ./cmd/device-agent
 	GOOS=darwin GOARCH=amd64 go build -o bin/macos-client/naisdevice-systray -ldflags "-s $(LDFLAGS)" ./cmd/systray
-	GOOS=darwin GOARCH=amd64 go build -o bin/macos-client/naisdevice-helper -ldflags "-s $(LDFLAGS)" ./cmd/device-agent-helper
+	GOOS=darwin GOARCH=amd64 go build -o bin/macos-client/naisdevice-helper -ldflags "-s $(LDFLAGS)" ./cmd/helper
 
 # Run by GitHub actions on linux
 windows-client: cmd/device-agent/icons.go
 	mkdir -p ./bin/windows-client
 	go get github.com/akavel/rsrc
-	${GOPATH}/bin/rsrc -arch amd64 -manifest ./packaging/windows/admin_manifest.xml -ico assets/nais-logo-blue.ico -o ./cmd/device-agent-helper/main_windows.syso
+	${GOPATH}/bin/rsrc -arch amd64 -manifest ./packaging/windows/admin_manifest.xml -ico assets/nais-logo-blue.ico -o ./cmd/helper/main_windows.syso
 	${GOPATH}/bin/rsrc -ico assets/nais-logo-blue.ico -o ./cmd/device-agent/main_windows.syso
 	GOOS=windows GOARCH=amd64 go build -o bin/windows-client/naisdevice-systray.exe -ldflags "-s $(LDFLAGS) -H=windowsgui" ./cmd/systray
 	GOOS=windows GOARCH=amd64 go build -o bin/windows-client/naisdevice-agent.exe -ldflags "-s $(LDFLAGS) -H=windowsgui" ./cmd/device-agent
-	GOOS=windows GOARCH=amd64 go build -o bin/windows-client/naisdevice-helper.exe -ldflags "-s $(LDFLAGS)" ./cmd/device-agent-helper
+	GOOS=windows GOARCH=amd64 go build -o bin/windows-client/naisdevice-helper.exe -ldflags "-s $(LDFLAGS)" ./cmd/helper
 
 local:
 	mkdir -p ./bin/local

--- a/cmd/device-agent/main.go
+++ b/cmd/device-agent/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/nais/device/device-agent/config"
 	"github.com/nais/device/device-agent/filesystem"
@@ -36,7 +37,8 @@ func main() {
 	flag.Parse()
 	cfg.SetDefaults()
 
-	logger.SetupLogger(cfg.LogLevel, cfg.ConfigDir, "agent.log")
+	logDir := filepath.Join(cfg.ConfigDir, "logs")
+	logger.SetupLogger(cfg.LogLevel, logDir, "agent.log")
 
 	cfg.PopulateAgentConfiguration()
 

--- a/cmd/systray/main.go
+++ b/cmd/systray/main.go
@@ -37,7 +37,8 @@ func main() {
 	flag.StringVar(&cfg.GrpcAddress, "grpc-address", cfg.GrpcAddress, "path to device-agent unix socket")
 	flag.Parse()
 
-	logger.SetupLogger(cfg.LogLevel, cfg.ConfigDir, "systray.log")
+	logDir := filepath.Join(cfg.ConfigDir, "logs")
+	logger.SetupLogger(cfg.LogLevel, logDir, "systray.log")
 
 	conn, err := net.Dial("unix", cfg.GrpcAddress)
 	if err != nil {

--- a/device-agent/config/config.go
+++ b/device-agent/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	config2 "github.com/nais/device/pkg/helper/config"
 	"github.com/nais/device/pkg/pb"
 	"google.golang.org/protobuf/encoding/protojson"
 	"io/ioutil"
@@ -58,7 +59,7 @@ func DefaultConfig() Config {
 		ConfigDir:                userConfigDir,
 		LogLevel:                 "info",
 		GrpcAddress:              filepath.Join(userConfigDir, "agent.sock"),
-		DeviceAgentHelperAddress: filepath.Join(userConfigDir, "helper.sock"),
+		DeviceAgentHelperAddress: filepath.Join(config2.RuntimeDir, "helper.sock"),
 		OAuth2Config: oauth2.Config{
 			ClientID:    "8086d321-c6d3-4398-87da-0d54e3d93967",
 			Scopes:      []string{"openid", "6e45010d-2637-4a40-b91d-d4cbb451fb57/.default", "offline_access"},

--- a/packaging/linux/naisdevice-helper.service
+++ b/packaging/linux/naisdevice-helper.service
@@ -3,7 +3,7 @@ Description=Naisdevice helper
 Documentation=https://doc.nais.io/device
 
 [Service]
-ExecStart=/usr/sbin/naisdevice-helper --config-dir @@CONFIG_DIR@@
+ExecStart=/usr/sbin/naisdevice-helper
 Restart=always
 
 [Install]

--- a/packaging/linux/postinstall
+++ b/packaging/linux/postinstall
@@ -46,8 +46,6 @@ for directory in "$config_dir" "$log_dir"; do
 	chmod 700 "$directory"
 done
 
-sed -i "s%@@CONFIG_DIR@@%${config_dir}%" "${unit_file}"
-
 cp /sys/devices/virtual/dmi/id/product_serial "${config_dir}"
 
 chown -R "${user}:" "${config_dir}"

--- a/packaging/linux/reset_certs.sh
+++ b/packaging/linux/reset_certs.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+nss_databases=()
+if [[ -d "$HOME/.pki/nssdb" ]]; then
+  nss_databases+=("sql:$HOME/.pki/nssdb/")
+fi
+for ff_profile in "$HOME"/.mozilla/firefox/*.default-release*/; do
+  nss_databases+=("$ff_profile")
+done
+
+if [[ ${#nss_databases[@]} -eq 0 ]]; then
+  echo "no supported nss databases found."
+  exit 1
+fi
+
+for db in "${nss_databases[@]}"; do
+  while certutil -d "$db" -D -n naisdevice &> /dev/null; do
+    echo "removed naisdevice cert from '$db'"
+    continue
+  done
+
+done
+
+echo "Done resettings browser certs"

--- a/packaging/macos/postinstall
+++ b/packaging/macos/postinstall
@@ -29,8 +29,6 @@ cat << EOF > "$destination"
                 <string>/Applications/naisdevice.app/Contents/MacOS/naisdevice-helper</string>
                 <string>--interface</string>
                 <string>utun69</string>
-                <string>--config-dir</string>
-                <string>$config_dir</string>
         </array>
         <key>RunAtLoad</key>
         <true/>

--- a/packaging/macos/preinstall
+++ b/packaging/macos/preinstall
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-pkill device-agent
-pkill device-agent-helper
 pkill naisdevice-systray
 pkill naisdevice-agent
 pkill naisdevice-helper

--- a/packaging/windows/naisdevice.wxs
+++ b/packaging/windows/naisdevice.wxs
@@ -138,7 +138,7 @@
                     Start="auto"
                     Account="NT AUTHORITY\SYSTEM"
                     ErrorControl="normal"
-                    Arguments="--interface utun69 --config-dir &quot;[APP_DATA_FOLDER]\&quot;"
+                    Arguments="--interface utun69"
             />
             <ServiceControl Id="StartService" Start="install" Stop="both" Remove="uninstall" Name="NaisDeviceHelper" Wait="yes"/>
         </Component>

--- a/pkg/device-helper/config.go
+++ b/pkg/device-helper/config.go
@@ -1,9 +1,0 @@
-package device_helper
-
-type Config struct {
-	Interface           string
-	WireGuardConfigPath string
-	ConfigDir           string
-	LogLevel            string
-	GrpcAddress         string
-}

--- a/pkg/helper/config.go
+++ b/pkg/helper/config.go
@@ -1,0 +1,6 @@
+package helper
+
+type Config struct {
+	Interface           string
+	LogLevel            string
+}

--- a/pkg/helper/config/config_darwin.go
+++ b/pkg/helper/config/config_darwin.go
@@ -1,0 +1,7 @@
+package config
+
+const (
+	RuntimeDir = "/run/naisdevice"
+	LogDir     = "/var/log/naisdevice"
+	ConfigDir  = "/etc/naisdevice"
+)

--- a/pkg/helper/config/config_darwin.go
+++ b/pkg/helper/config/config_darwin.go
@@ -3,5 +3,5 @@ package config
 const (
 	ConfigDir  = "/etc/naisdevice"
 	LogDir     = "/var/log/naisdevice"
-	RuntimeDir = "/run/naisdevice"
+	RuntimeDir = "/var/run/naisdevice"
 )

--- a/pkg/helper/config/config_darwin.go
+++ b/pkg/helper/config/config_darwin.go
@@ -1,7 +1,7 @@
 package config
 
 const (
-	RuntimeDir = "/run/naisdevice"
-	LogDir     = "/var/log/naisdevice"
 	ConfigDir  = "/etc/naisdevice"
+	LogDir     = "/var/log/naisdevice"
+	RuntimeDir = "/run/naisdevice"
 )

--- a/pkg/helper/config/config_linux.go
+++ b/pkg/helper/config/config_linux.go
@@ -2,6 +2,6 @@ package config
 
 const (
 	ConfigDir  = "/etc/naisdevice"
-	RuntimeDir = "/run/naisdevice"
 	LogDir     = "/var/log/naisdevice"
+	RuntimeDir = "/run/naisdevice"
 )

--- a/pkg/helper/config/config_linux.go
+++ b/pkg/helper/config/config_linux.go
@@ -1,0 +1,7 @@
+package config
+
+const (
+	ConfigDir  = "/etc/naisdevice"
+	RuntimeDir = "/run/naisdevice"
+	LogDir     = "/var/log/naisdevice"
+)

--- a/pkg/helper/config/config_windows.go
+++ b/pkg/helper/config/config_windows.go
@@ -1,7 +1,7 @@
 package config
 
 const (
-	RuntimeDir = `c:\ProgramData\NAV\naisdevice\run`
-	LogDir     = `c:\ProgramData\NAV\naisdevice\logs`
 	ConfigDir  = `c:\ProgramData\NAV\naisdevice\etc`
+	LogDir     = `c:\ProgramData\NAV\naisdevice\logs`
+	RuntimeDir = `c:\ProgramData\NAV\naisdevice\run`
 )

--- a/pkg/helper/config/config_windows.go
+++ b/pkg/helper/config/config_windows.go
@@ -1,0 +1,7 @@
+package config
+
+const (
+	RuntimeDir = `c:\ProgramData\NAV\naisdevice\run`
+	LogDir     = `c:\ProgramData\NAV\naisdevice\logs`
+	ConfigDir  = `c:\ProgramData\NAV\naisdevice\etc`
+)

--- a/pkg/helper/helper_darwin.go
+++ b/pkg/helper/helper_darwin.go
@@ -1,10 +1,10 @@
-package device_helper
+package helper
 
 import (
 	"context"
 	"fmt"
+	"github.com/nais/device/pkg/config/helper"
 	"os/exec"
-	"path/filepath"
 	"strings"
 
 	"github.com/nais/device/pkg/pb"
@@ -12,9 +12,9 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var (
-	WireGuardGoBinary = filepath.Join("/", "Applications", "naisdevice.app", "Contents", "MacOS", "wireguard-go")
-	WireGuardBinary   = filepath.Join("/", "Applications", "naisdevice.app", "Contents", "MacOS", "wg")
+const (
+	WireGuardBinary   = "/Applications/naisdevice.app/Contents/MacOS/wg"
+	WireGuardGoBinary = "/Applications/naisdevice.app/Contents/MacOS/wireguard-go"
 )
 
 type DarwinConfigurator struct {
@@ -30,7 +30,7 @@ func New(helperConfig Config) *DarwinConfigurator {
 }
 
 func (c *DarwinConfigurator) Prerequisites() error {
-	if err := filesExist(WireGuardBinary, WireGuardGoBinary); err != nil {
+	if err := filesExist(WireGuardBinary, helper.WireGuardGoBinary); err != nil {
 		return fmt.Errorf("verifying if file exists: %w", err)
 	}
 
@@ -38,7 +38,7 @@ func (c *DarwinConfigurator) Prerequisites() error {
 }
 
 func (c *DarwinConfigurator) SyncConf(ctx context.Context, cfg *pb.Configuration) error {
-	cmd := exec.CommandContext(ctx, WireGuardBinary, "syncconf", c.helperConfig.Interface, c.helperConfig.WireGuardConfigPath)
+	cmd := exec.CommandContext(ctx, WireGuardBinary, "syncconf", c.helperConfig.Interface, WireGuardConfigPath)
 	if b, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("running syncconf: %w: %v", err, string(b))
 	}
@@ -72,7 +72,7 @@ func (c *DarwinConfigurator) SetupInterface(ctx context.Context, cfg *pb.Configu
 	}
 
 	commands := [][]string{
-		{WireGuardGoBinary, c.helperConfig.Interface},
+		{helper.WireGuardGoBinary, c.helperConfig.Interface},
 		{"ifconfig", c.helperConfig.Interface, "inet", cfg.GetDeviceIP() + "/21", cfg.GetDeviceIP(), "add"},
 		{"ifconfig", c.helperConfig.Interface, "mtu", "1360"},
 		{"ifconfig", c.helperConfig.Interface, "up"},
@@ -87,7 +87,7 @@ func (c *DarwinConfigurator) TeardownInterface(ctx context.Context) error {
 		return nil
 	}
 
-	cmd := exec.CommandContext(ctx, "pkill", "-f", fmt.Sprintf("%s %s", WireGuardGoBinary, c.helperConfig.Interface))
+	cmd := exec.CommandContext(ctx, "pkill", "-f", fmt.Sprintf("%s %s", helper.WireGuardGoBinary, c.helperConfig.Interface))
 	out, err := cmd.CombinedOutput()
 
 	if err != nil {
@@ -99,6 +99,6 @@ func (c *DarwinConfigurator) TeardownInterface(ctx context.Context) error {
 }
 
 func (c *DarwinConfigurator) interfaceExists(ctx context.Context) bool {
-	cmd := exec.CommandContext(ctx, "pgrep", "-f", fmt.Sprintf("%s %s", WireGuardGoBinary, c.helperConfig.Interface))
+	cmd := exec.CommandContext(ctx, "pgrep", "-f", fmt.Sprintf("%s %s", helper.WireGuardGoBinary, c.helperConfig.Interface))
 	return cmd.Run() == nil
 }

--- a/pkg/helper/helper_darwin.go
+++ b/pkg/helper/helper_darwin.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	WireGuardBinary   = "/Applications/naisdevice.app/Contents/MacOS/wg"
-	WireGuardGoBinary = "/Applications/naisdevice.app/Contents/MacOS/wireguard-go"
+	wireGuardBinary   = "/Applications/naisdevice.app/Contents/MacOS/wg"
+	wireGuardGoBinary = "/Applications/naisdevice.app/Contents/MacOS/wireguard-go"
 )
 
 type DarwinConfigurator struct {
@@ -29,7 +29,7 @@ func New(helperConfig Config) *DarwinConfigurator {
 }
 
 func (c *DarwinConfigurator) Prerequisites() error {
-	if err := filesExist(WireGuardBinary, WireGuardGoBinary); err != nil {
+	if err := filesExist(wireGuardBinary, wireGuardGoBinary); err != nil {
 		return fmt.Errorf("verifying if file exists: %w", err)
 	}
 
@@ -37,7 +37,7 @@ func (c *DarwinConfigurator) Prerequisites() error {
 }
 
 func (c *DarwinConfigurator) SyncConf(ctx context.Context, cfg *pb.Configuration) error {
-	cmd := exec.CommandContext(ctx, WireGuardBinary, "syncconf", c.helperConfig.Interface, WireGuardConfigPath)
+	cmd := exec.CommandContext(ctx, wireGuardBinary, "syncconf", c.helperConfig.Interface, WireGuardConfigPath)
 	if b, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("running syncconf: %w: %v", err, string(b))
 	}
@@ -71,7 +71,7 @@ func (c *DarwinConfigurator) SetupInterface(ctx context.Context, cfg *pb.Configu
 	}
 
 	commands := [][]string{
-		{WireGuardGoBinary, c.helperConfig.Interface},
+		{wireGuardGoBinary, c.helperConfig.Interface},
 		{"ifconfig", c.helperConfig.Interface, "inet", cfg.GetDeviceIP() + "/21", cfg.GetDeviceIP(), "add"},
 		{"ifconfig", c.helperConfig.Interface, "mtu", "1360"},
 		{"ifconfig", c.helperConfig.Interface, "up"},
@@ -86,7 +86,7 @@ func (c *DarwinConfigurator) TeardownInterface(ctx context.Context) error {
 		return nil
 	}
 
-	cmd := exec.CommandContext(ctx, "pkill", "-f", fmt.Sprintf("%s %s", WireGuardGoBinary, c.helperConfig.Interface))
+	cmd := exec.CommandContext(ctx, "pkill", "-f", fmt.Sprintf("%s %s", wireGuardGoBinary, c.helperConfig.Interface))
 	out, err := cmd.CombinedOutput()
 
 	if err != nil {
@@ -98,6 +98,6 @@ func (c *DarwinConfigurator) TeardownInterface(ctx context.Context) error {
 }
 
 func (c *DarwinConfigurator) interfaceExists(ctx context.Context) bool {
-	cmd := exec.CommandContext(ctx, "pgrep", "-f", fmt.Sprintf("%s %s", WireGuardGoBinary, c.helperConfig.Interface))
+	cmd := exec.CommandContext(ctx, "pgrep", "-f", fmt.Sprintf("%s %s", wireGuardGoBinary, c.helperConfig.Interface))
 	return cmd.Run() == nil
 }

--- a/pkg/helper/helper_darwin.go
+++ b/pkg/helper/helper_darwin.go
@@ -3,7 +3,6 @@ package helper
 import (
 	"context"
 	"fmt"
-	"github.com/nais/device/pkg/config/helper"
 	"os/exec"
 	"strings"
 
@@ -30,7 +29,7 @@ func New(helperConfig Config) *DarwinConfigurator {
 }
 
 func (c *DarwinConfigurator) Prerequisites() error {
-	if err := filesExist(WireGuardBinary, helper.WireGuardGoBinary); err != nil {
+	if err := filesExist(WireGuardBinary, WireGuardGoBinary); err != nil {
 		return fmt.Errorf("verifying if file exists: %w", err)
 	}
 
@@ -72,7 +71,7 @@ func (c *DarwinConfigurator) SetupInterface(ctx context.Context, cfg *pb.Configu
 	}
 
 	commands := [][]string{
-		{helper.WireGuardGoBinary, c.helperConfig.Interface},
+		{WireGuardGoBinary, c.helperConfig.Interface},
 		{"ifconfig", c.helperConfig.Interface, "inet", cfg.GetDeviceIP() + "/21", cfg.GetDeviceIP(), "add"},
 		{"ifconfig", c.helperConfig.Interface, "mtu", "1360"},
 		{"ifconfig", c.helperConfig.Interface, "up"},
@@ -87,7 +86,7 @@ func (c *DarwinConfigurator) TeardownInterface(ctx context.Context) error {
 		return nil
 	}
 
-	cmd := exec.CommandContext(ctx, "pkill", "-f", fmt.Sprintf("%s %s", helper.WireGuardGoBinary, c.helperConfig.Interface))
+	cmd := exec.CommandContext(ctx, "pkill", "-f", fmt.Sprintf("%s %s", WireGuardGoBinary, c.helperConfig.Interface))
 	out, err := cmd.CombinedOutput()
 
 	if err != nil {
@@ -99,6 +98,6 @@ func (c *DarwinConfigurator) TeardownInterface(ctx context.Context) error {
 }
 
 func (c *DarwinConfigurator) interfaceExists(ctx context.Context) bool {
-	cmd := exec.CommandContext(ctx, "pgrep", "-f", fmt.Sprintf("%s %s", helper.WireGuardGoBinary, c.helperConfig.Interface))
+	cmd := exec.CommandContext(ctx, "pgrep", "-f", fmt.Sprintf("%s %s", WireGuardGoBinary, c.helperConfig.Interface))
 	return cmd.Run() == nil
 }

--- a/pkg/helper/helper_linux.go
+++ b/pkg/helper/helper_linux.go
@@ -1,4 +1,4 @@
-package device_helper
+package helper
 
 import (
 	"context"
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	WireGuardBinary = "/usr/bin/wg"
+	wireguardBinary = "/usr/bin/wg"
 )
 
 func New(helperConfig Config) *LinuxConfigurator {
@@ -28,7 +28,7 @@ type LinuxConfigurator struct {
 var _ OSConfigurator = &LinuxConfigurator{}
 
 func (c *LinuxConfigurator) Prerequisites() error {
-	if err := filesExist(WireGuardBinary); err != nil {
+	if err := filesExist(wireguardBinary); err != nil {
 		return fmt.Errorf("verifying if file exists: %w", err)
 	}
 
@@ -36,7 +36,7 @@ func (c *LinuxConfigurator) Prerequisites() error {
 }
 
 func (c *LinuxConfigurator) SyncConf(ctx context.Context, cfg *pb.Configuration) error {
-	cmd := exec.CommandContext(ctx, WireGuardBinary, "syncconf", c.helperConfig.Interface, c.helperConfig.WireGuardConfigPath)
+	cmd := exec.CommandContext(ctx, wireguardBinary, "syncconf", c.helperConfig.Interface, WireGuardConfigPath)
 	if b, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("running syncconf: %w: %v", err, string(b))
 	}

--- a/pkg/helper/helper_windows.go
+++ b/pkg/helper/helper_windows.go
@@ -78,7 +78,7 @@ func (service *MyService) ControlChannel() <-chan ControlEvent {
 }
 
 func interfaceExists(ctx context.Context, iface string) bool {
-	queryService := exec.CommandContext(ctx, "sc", "query", serviceName(iface))
+	queryService := exec.CommandContext(ctx, "sc", "query", tunnelName(iface))
 	if err := queryService.Run(); err != nil {
 		return false
 	} else {
@@ -129,8 +129,8 @@ func (configurator *WindowsConfigurator) SyncConf(ctx context.Context, cfg *pb.C
 		log.Debugf("new: %s", string(newWireGuardConfig))
 
 		commands := [][]string{
-			{"net", "stop", serviceName(configurator.helperConfig.Interface)},
-			{"net", "start", serviceName(configurator.helperConfig.Interface)},
+			{"net", "stop", tunnelName(configurator.helperConfig.Interface)},
+			{"net", "start", tunnelName(configurator.helperConfig.Interface)},
 		}
 
 		return runCommands(ctx, commands)
@@ -159,7 +159,7 @@ func (configurator *WindowsConfigurator) TeardownInterface(ctx context.Context) 
 	return nil
 }
 
-func serviceName(interfaceName string) string {
+func tunnelName(interfaceName string) string {
 	return fmt.Sprintf("WireGuardTunnel$%s", interfaceName)
 }
 

--- a/pkg/helper/helper_windows.go
+++ b/pkg/helper/helper_windows.go
@@ -1,4 +1,4 @@
-package device_helper
+package helper
 
 import (
 	"bytes"
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	WireGuardBinary = `c:\Program Files\WireGuard\wireguard.exe`
 	ServiceName     = "naisdevice-agent-helper"
+	WireGuardBinary = `c:\Program Files\WireGuard\wireguard.exe`
 )
 
 type MyService struct {
@@ -91,7 +91,7 @@ func (configurator *WindowsConfigurator) SetupInterface(ctx context.Context, cfg
 		return nil
 	}
 
-	installService := exec.CommandContext(ctx, WireGuardBinary, "/installtunnelservice", configurator.helperConfig.WireGuardConfigPath)
+	installService := exec.CommandContext(ctx, WireGuardBinary, "/installtunnelservice", WireGuardConfigPath)
 	if b, err := installService.CombinedOutput(); err != nil {
 		return fmt.Errorf("installing tunnel service: %v: %v", err, string(b))
 	} else {
@@ -110,7 +110,7 @@ func (configurator *WindowsConfigurator) SetupRoutes(ctx context.Context, gatewa
 }
 
 func (configurator *WindowsConfigurator) SyncConf(ctx context.Context, cfg *pb.Configuration) error {
-	newWireGuardConfig, err := ioutil.ReadFile(configurator.helperConfig.WireGuardConfigPath)
+	newWireGuardConfig, err := ioutil.ReadFile(WireGuardConfigPath)
 	if err != nil {
 		return fmt.Errorf("reading WireGuard config file: %w", err)
 	}

--- a/pkg/helper/helper_windows.go
+++ b/pkg/helper/helper_windows.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	ServiceName     = "naisdevice-agent-helper"
-	WireGuardBinary = `c:\Program Files\WireGuard\wireguard.exe`
+	serviceName     = "naisdevice-agent-helper"
+	wireGuardBinary = `c:\Program Files\WireGuard\wireguard.exe`
 )
 
 type MyService struct {
@@ -47,7 +47,7 @@ const (
 )
 
 func (configurator *WindowsConfigurator) Prerequisites() error {
-	if err := filesExist(WireGuardBinary); err != nil {
+	if err := filesExist(wireGuardBinary); err != nil {
 		return fmt.Errorf("verifying if file exists: %w", err)
 	}
 
@@ -62,7 +62,7 @@ func (configurator *WindowsConfigurator) Prerequisites() error {
 
 	go func() {
 		s := NewService()
-		err = svc.Run(ServiceName, s)
+		err = svc.Run(serviceName, s)
 		if err != nil {
 			log.Fatalf("Running service: %v", err)
 		}
@@ -91,7 +91,7 @@ func (configurator *WindowsConfigurator) SetupInterface(ctx context.Context, cfg
 		return nil
 	}
 
-	installService := exec.CommandContext(ctx, WireGuardBinary, "/installtunnelservice", WireGuardConfigPath)
+	installService := exec.CommandContext(ctx, wireGuardBinary, "/installtunnelservice", WireGuardConfigPath)
 	if b, err := installService.CombinedOutput(); err != nil {
 		return fmt.Errorf("installing tunnel service: %v: %v", err, string(b))
 	} else {
@@ -145,7 +145,7 @@ func (configurator *WindowsConfigurator) TeardownInterface(ctx context.Context) 
 		return nil
 	}
 
-	uninstallService := exec.CommandContext(ctx, WireGuardBinary, "/uninstalltunnelservice", configurator.helperConfig.Interface)
+	uninstallService := exec.CommandContext(ctx, wireGuardBinary, "/uninstalltunnelservice", configurator.helperConfig.Interface)
 
 	b, err := uninstallService.CombinedOutput()
 	if err != nil {

--- a/pkg/helper/util.go
+++ b/pkg/helper/util.go
@@ -1,4 +1,4 @@
-package device_helper
+package helper
 
 import (
 	"context"

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -9,10 +9,13 @@ import (
 	easy "github.com/t-tomalak/logrus-easy-formatter"
 )
 
-func SetupLogger(level, configDir, filename string) {
-	logDirPath := filepath.Join(configDir, "logs")
+func SetupLogger(level, logDir, filename string) {
+	err := os.MkdirAll(logDir, 755)
+	if err != nil {
+		log.Fatal("Creating log dir: %v", err)
+	}
 
-	logFilePath := filepath.Join(logDirPath, filename)
+	logFilePath := filepath.Join(logDir, filename)
 	logFile, err := os.OpenFile(logFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0664)
 	if err != nil {
 		log.Fatalf("unable to open log file %s, error: %v", logFilePath, err)
@@ -22,7 +25,6 @@ func SetupLogger(level, configDir, filename string) {
 	mw := io.MultiWriter(logFile, os.Stdout)
 	log.SetOutput(mw)
 
-	log.Infof("Path: %s", configDir)
 	loglevel, err := log.ParseLevel(level)
 	if err != nil {
 		log.Errorf("unable to parse log level %s, error: %v", level, err)

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -12,7 +12,7 @@ import (
 func SetupLogger(level, logDir, filename string) {
 	err := os.MkdirAll(logDir, 755)
 	if err != nil {
-		log.Fatal("Creating log dir: %v", err)
+		log.Fatalf("Creating log dir: %v", err)
 	}
 
 	logFilePath := filepath.Join(logDir, filename)


### PR DESCRIPTION
this changes moves all of `helpers` files to system default locations
(except for windows, keeps everything in the programdata folder)

also remove device from name, as it is quite redundant