### PR TITLE
attempt to make service shutdown faster (windows)

### DIFF
--- a/cmd/helper/main.go
+++ b/cmd/helper/main.go
@@ -30,7 +30,7 @@ func init() {
 
 func main() {
 	programContext, cancel := context.WithCancel(context.Background())
-	// for windows service control, noop on other unix
+	// for windows service control, noop on unix
 	err := helper.StartService(programContext, cancel)
 	if err != nil {
 		log.Fatalf("Starting windows service: %v", err)

--- a/pkg/helper/service_unix.go
+++ b/pkg/helper/service_unix.go
@@ -1,0 +1,9 @@
+//go:build linux || darwin
+
+package helper
+
+import "context"
+
+func StartService(programContext context.Context, cancel context.CancelFunc) error {
+	return nil
+}

--- a/pkg/helper/service_windows.go
+++ b/pkg/helper/service_windows.go
@@ -1,0 +1,71 @@
+package helper
+
+import (
+	"context"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sys/windows/svc"
+)
+
+const serviceName = "naisdevice-agent-helper"
+
+type MyService struct {
+	programContext context.Context
+	cancel         context.CancelFunc
+}
+
+func StartService(programContext context.Context, cancel context.CancelFunc) error {
+	isWindowsService, err := svc.IsWindowsService()
+	if err != nil {
+		return err
+	}
+
+	if !isWindowsService {
+		return nil
+	}
+
+	go func() {
+		s := &MyService{
+			programContext: programContext,
+			cancel:         cancel,
+		}
+
+		err = svc.Run(serviceName, s)
+		if err != nil {
+			log.Fatalf("Running service: %v", err)
+		}
+	}()
+
+	log.Infof("ran service handler")
+	return nil
+}
+
+func (service *MyService) Execute(args []string, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (ssec bool, errno uint32) {
+	const cmdsAccepted = svc.AcceptStop | svc.AcceptShutdown
+	changes <- svc.Status{State: svc.StartPending}
+	log.Infof("service started with args: %v", args)
+	changes <- svc.Status{State: svc.Running, Accepts: cmdsAccepted}
+loop:
+	for {
+		select {
+		case <-service.programContext.Done():
+			break loop
+		case c := <-r:
+			switch c.Cmd {
+			case svc.Interrogate:
+				changes <- c.CurrentStatus
+				time.Sleep(100 * time.Millisecond)
+				changes <- c.CurrentStatus
+			case svc.Stop, svc.Shutdown:
+				log.Infof("Stop service: %v", c)
+				service.cancel()
+				break loop
+			default:
+				log.Errorf("unexpected control request #%d", c)
+			}
+		}
+	}
+	changes <- svc.Status{State: svc.StopPending}
+	return
+}


### PR DESCRIPTION
Currently it seems like the helper on windows does not shut down properly when the windows server is stopped. This might be because we don't actually do anything when we get the signal stop stop/shutdown from the service handler. Attempt to fix it in this PR.

Also: i moved the service code to a separate file as it had nothing to do with the os configurator it was mixed in with earlier.