### PR TITLE
add persistent keepalive wireguard config for prometheus peer

### DIFF
--- a/pkg/apiserver/config/config.go
+++ b/pkg/apiserver/config/config.go
@@ -104,7 +104,7 @@ func (cfg *Config) APIServerPeer() *pb.Gateway {
 func (cfg *Config) StaticPeers() []*pb.Gateway {
 	return []*pb.Gateway{
 		{
-			Name:      "prometheus",
+			Name:      wireguard.PrometheusPeerName,
 			PublicKey: cfg.PrometheusPublicKey,
 			Ip:        cfg.PrometheusTunnelIP,
 		},

--- a/pkg/apiserver/wireguard/wireguard.go
+++ b/pkg/apiserver/wireguard/wireguard.go
@@ -77,7 +77,7 @@ AllowedIPs = %s/32
 PublicKey = %s
 `
 	wgConfig += fmt.Sprintf(peerTemplate, conf.PrometheusTunnelIP, conf.PrometheusPublicKey)
-	wgConfig += "PersistentKeepalive = 25"
+	wgConfig += "PersistentKeepalive = 25\n"
 
 	for _, device := range devices {
 		wgConfig += fmt.Sprintf(peerTemplate, device.Ip, device.PublicKey)

--- a/pkg/apiserver/wireguard/wireguard.go
+++ b/pkg/apiserver/wireguard/wireguard.go
@@ -77,6 +77,7 @@ AllowedIPs = %s/32
 PublicKey = %s
 `
 	wgConfig += fmt.Sprintf(peerTemplate, conf.PrometheusTunnelIP, conf.PrometheusPublicKey)
+	wgConfig += "PersistentKeepalive = 25"
 
 	for _, device := range devices {
 		wgConfig += fmt.Sprintf(peerTemplate, device.Ip, device.PublicKey)

--- a/pkg/gateway-agent/config.go
+++ b/pkg/gateway-agent/config.go
@@ -75,7 +75,7 @@ func (c Config) StaticPeers() []wireguard.Peer {
 			Ip:        c.APIServerPrivateIP,
 		},
 		&pb.Gateway{
-			Name:      "prometheus",
+			Name:      wireguard.PrometheusPeerName,
 			PublicKey: c.PrometheusPublicKey,
 			Ip:        c.PrometheusTunnelIP,
 		},

--- a/pkg/wireguard/config.go
+++ b/pkg/wireguard/config.go
@@ -9,6 +9,8 @@ import (
 	"github.com/nais/device/pkg/pb"
 )
 
+const PrometheusPeerName = "prometheus"
+
 type Peer interface {
 	GetName() string
 	GetPublicKey() string
@@ -47,6 +49,9 @@ func (cfg *Config) MarshalINI(w io.Writer) error {
 		fprintNonEmpty(ew, "PublicKey = %s\n", peer.GetPublicKey())
 		fprintNonEmpty(ew, "AllowedIPs = %s\n", strings.Join(peer.GetAllowedIPs(), ","))
 		fprintNonEmpty(ew, "Endpoint = %s\n", peer.GetEndpoint())
+		if peer.GetName() == PrometheusPeerName {
+			fmt.Fprint(ew, "PersistentKeepalive = 25\n")
+		}
 		fmt.Fprintf(ew, "\n")
 	}
 


### PR DESCRIPTION
With this change we could probably make the `prometheus-agent` run on a VM without public ip.