### PR TITLE
fix systray log buttons

### DIFF
--- a/cmd/device-agent/main.go
+++ b/cmd/device-agent/main.go
@@ -61,8 +61,8 @@ func main() {
 	programContext, programCancel := context.WithCancel(context.Background())
 	handleSignals(programCancel)
 
-	logDir := filepath.Join(cfg.ConfigDir, "logs")
-	logger.SetupLogger(cfg.LogLevel, logDir, "agent")
+	logDir := filepath.Join(cfg.ConfigDir, logger.LogDir)
+	logger.SetupLogger(cfg.LogLevel, logDir, logger.Agent)
 
 	cfg.PopulateAgentConfiguration()
 

--- a/cmd/helper/main.go
+++ b/cmd/helper/main.go
@@ -8,15 +8,16 @@ import (
 	"syscall"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+	flag "github.com/spf13/pflag"
+	"google.golang.org/grpc"
+
 	"github.com/nais/device/pkg/helper"
 	"github.com/nais/device/pkg/helper/config"
 	"github.com/nais/device/pkg/logger"
 	"github.com/nais/device/pkg/pb"
 	"github.com/nais/device/pkg/unixsocket"
 	"github.com/nais/device/pkg/version"
-	log "github.com/sirupsen/logrus"
-	flag "github.com/spf13/pflag"
-	"google.golang.org/grpc"
 )
 
 var cfg = helper.Config{}
@@ -38,7 +39,7 @@ func main() {
 
 	osConfigurator := helper.New(cfg)
 
-	logger.SetupLogger(cfg.LogLevel, config.LogDir, "helper")
+	logger.SetupLogger(cfg.LogLevel, config.LogDir, logger.Helper)
 
 	log.Infof("naisdevice-helper %s starting up", version.Version)
 	log.Infof("configuration: %+v", cfg)

--- a/cmd/systray/main.go
+++ b/cmd/systray/main.go
@@ -10,13 +10,14 @@ import (
 	"syscall"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+	flag "github.com/spf13/pflag"
+
 	"github.com/nais/device/pkg/config"
 	"github.com/nais/device/pkg/logger"
 	"github.com/nais/device/pkg/notify"
 	"github.com/nais/device/pkg/systray"
 	"github.com/nais/device/pkg/version"
-	log "github.com/sirupsen/logrus"
-	flag "github.com/spf13/pflag"
 )
 
 func handleSignals(cancel context.CancelFunc) {
@@ -61,8 +62,8 @@ func main() {
 	flag.StringVar(&cfg.GrpcAddress, "grpc-address", cfg.GrpcAddress, "path to device-agent unix socket")
 	flag.Parse()
 
-	logDir := filepath.Join(cfg.ConfigDir, "logs")
-	logger.SetupLogger(cfg.LogLevel, logDir, "systray")
+	logDir := filepath.Join(cfg.ConfigDir, logger.LogDir)
+	logger.SetupLogger(cfg.LogLevel, logDir, logger.Systray)
 
 	conn, err := net.Dial("unix", cfg.GrpcAddress)
 	if err != nil {

--- a/pkg/device-agent/eventloop.go
+++ b/pkg/device-agent/eventloop.go
@@ -317,7 +317,7 @@ func (das *DeviceAgentServer) EventLoop(ctx context.Context) {
 						case codes.OK:
 							attempt = 0
 						case codes.Unavailable:
-							log.Warnf("Synchronize config: not connected to API server!")
+							log.Warnf("Synchronize config: not connected to API server: %v", err)
 							time.Sleep(apiServerRetryInterval)
 						case codes.Unauthenticated:
 							log.Errorf("Logging in: %s", err)

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -10,9 +10,17 @@ import (
 	easy "github.com/t-tomalak/logrus-easy-formatter"
 )
 
-const logfileMaxAge = time.Hour * 24 * 7
+const (
+	Agent   = "agent"
+	Helper  = "helper"
+	Systray = "systray"
 
-func SetupLogger(level, logDir, name string) {
+	LogDir = "logs"
+
+	logfileMaxAge = time.Hour * 24 * 7
+)
+
+func SetupLogger(level, logDir, prefix string) {
 	err := os.MkdirAll(logDir, 0o755)
 	if err != nil {
 		log.Fatalf("Creating log dir: %v", err)
@@ -24,9 +32,9 @@ func SetupLogger(level, logDir, name string) {
 	}
 
 	// clean up old log file without date
-	_ = os.Remove(filepath.Join(logDir, name+".log"))
+	_ = os.Remove(filepath.Join(logDir, prefix+".log"))
 
-	filename := createLogFileName(name, time.Now())
+	filename := createLogFileName(prefix, time.Now())
 	logFilePath := filepath.Join(logDir, filename)
 
 	logFile, err := os.OpenFile(logFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o664)

--- a/pkg/logger/rotate.go
+++ b/pkg/logger/rotate.go
@@ -61,6 +61,10 @@ func createLogFileName(prefix string, t time.Time) string {
 	return fmt.Sprintf("%s_%s.log", prefix, t.Format(time.DateOnly))
 }
 
+func LatestFilepath(logDirPath, prefix string) string {
+	return filepath.Join(logDirPath, LatestFilename(logDirPath, prefix))
+}
+
 func LatestFilename(logDirPath, prefix string) string {
 	logFiles, err := os.ReadDir(logDirPath)
 	if err != nil {

--- a/pkg/systray/gui.go
+++ b/pkg/systray/gui.go
@@ -423,13 +423,13 @@ func (gui *Gui) handleGuiEvent(guiEvent GuiEvent) {
 	case HelperLogClicked:
 		err := open.Open(filepath.Join(gui.Config.ConfigDir, "logs", "helper.log"))
 		if err != nil {
-			log.Warn("opening device agent helper log: %w", err)
+			log.Warnf("opening device agent helper log: %v", err)
 		}
 
 	case DeviceLogClicked:
 		err := open.Open(filepath.Join(gui.Config.ConfigDir, "logs", "agent.log"))
 		if err != nil {
-			log.Warn("opening device agent log: %w", err)
+			log.Warnf("opening device agent log: %v", err)
 		}
 
 	case ZipLogsClicked:
@@ -451,13 +451,13 @@ func (gui *Gui) handleGuiEvent(guiEvent GuiEvent) {
 	case LogClicked:
 		err := open.Open(filepath.Join(gui.Config.ConfigDir, "logs", "systray.log"))
 		if err != nil {
-			log.Warn("opening device agent log: %w", err)
+			log.Warnf("opening systray log: %v", err)
 		}
 
 	case AcceptableUseClicked:
 		err := open.Open("https://naisdevice-approval.nais.io/")
 		if err != nil {
-			log.Warn("opening device agent log: %w", err)
+			log.Warnf("opening naisdevice approval page: %v", err)
 		}
 	case QuitClicked:
 		_, err := gui.DeviceAgentClient.Logout(context.Background(), &pb.LogoutRequest{})

--- a/pkg/systray/gui.go
+++ b/pkg/systray/gui.go
@@ -423,16 +423,14 @@ func (gui *Gui) handleGuiEvent(guiEvent GuiEvent) {
 		}
 
 	case HelperLogClicked:
-		logFilename := logger.LatestFilename(helperconfig.LogDir, logger.Helper)
-		err := open.Open(filepath.Join(helperconfig.LogDir, logFilename))
+		err := open.Open(logger.LatestFilepath(helperconfig.LogDir, logger.Helper))
 		if err != nil {
 			log.Warnf("opening device agent helper log: %v", err)
 		}
 
 	case DeviceLogClicked:
 		logDirPath := filepath.Join(gui.Config.ConfigDir, logger.LogDir)
-		logFilename := logger.LatestFilename(logDirPath, logger.Agent)
-		err := open.Open(filepath.Join(logDirPath, logFilename))
+		err := open.Open(logger.LatestFilepath(logDirPath, logger.Agent))
 		if err != nil {
 			log.Warnf("opening device agent log: %v", err)
 		}
@@ -440,9 +438,9 @@ func (gui *Gui) handleGuiEvent(guiEvent GuiEvent) {
 	case ZipLogsClicked:
 		userLogDirPath := filepath.Join(gui.Config.ConfigDir, logger.LogDir)
 		logFiles := [3]string{
-			filepath.Join(userLogDirPath, logger.LatestFilename(userLogDirPath, logger.Agent)),
-			filepath.Join(helperconfig.LogDir, logger.LatestFilename(helperconfig.LogDir, logger.Helper)),
-			filepath.Join(userLogDirPath, logger.LatestFilename(userLogDirPath, logger.Systray)),
+			logger.LatestFilepath(userLogDirPath, logger.Agent),
+			logger.LatestFilepath(helperconfig.LogDir, logger.Helper),
+			logger.LatestFilepath(userLogDirPath, logger.Systray),
 		}
 		zipLocation, err := helper.ZipLogFiles(logFiles[:])
 		if err != nil {
@@ -455,8 +453,7 @@ func (gui *Gui) handleGuiEvent(guiEvent GuiEvent) {
 
 	case LogClicked:
 		logDirPath := filepath.Join(gui.Config.ConfigDir, logger.LogDir)
-		logFilename := logger.LatestFilename(logDirPath, logger.Systray)
-		err := open.Open(filepath.Join(logDirPath, logFilename))
+		err := open.Open(logger.LatestFilepath(logDirPath, logger.Systray))
 		if err != nil {
 			log.Warnf("opening systray log: %v", err)
 		}

--- a/pkg/systray/gui.go
+++ b/pkg/systray/gui.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/nais/device/pkg/helper"
+	helperconfig "github.com/nais/device/pkg/helper/config"
+	"github.com/nais/device/pkg/logger"
 
 	"github.com/nais/device/assets"
 	"github.com/nais/device/pkg/device-agent/open"
@@ -421,23 +423,26 @@ func (gui *Gui) handleGuiEvent(guiEvent GuiEvent) {
 		}
 
 	case HelperLogClicked:
-		err := open.Open(filepath.Join(gui.Config.ConfigDir, "logs", "helper.log"))
+		logFilename := logger.LatestFilename(helperconfig.LogDir, logger.Helper)
+		err := open.Open(filepath.Join(helperconfig.LogDir, logFilename))
 		if err != nil {
 			log.Warnf("opening device agent helper log: %v", err)
 		}
 
 	case DeviceLogClicked:
-		err := open.Open(filepath.Join(gui.Config.ConfigDir, "logs", "agent.log"))
+		logDirPath := filepath.Join(gui.Config.ConfigDir, logger.LogDir)
+		logFilename := logger.LatestFilename(logDirPath, logger.Agent)
+		err := open.Open(filepath.Join(logDirPath, logFilename))
 		if err != nil {
 			log.Warnf("opening device agent log: %v", err)
 		}
 
 	case ZipLogsClicked:
-		logDir := filepath.Join(gui.Config.ConfigDir, "logs")
+		userLogDirPath := filepath.Join(gui.Config.ConfigDir, logger.LogDir)
 		logFiles := [3]string{
-			filepath.Join(logDir, "helper.log"),
-			filepath.Join(logDir, "agent.log"),
-			filepath.Join(logDir, "systray.log"),
+			filepath.Join(userLogDirPath, logger.LatestFilename(userLogDirPath, logger.Agent)),
+			filepath.Join(helperconfig.LogDir, logger.LatestFilename(helperconfig.LogDir, logger.Helper)),
+			filepath.Join(userLogDirPath, logger.LatestFilename(userLogDirPath, logger.Systray)),
 		}
 		zipLocation, err := helper.ZipLogFiles(logFiles[:])
 		if err != nil {
@@ -449,7 +454,9 @@ func (gui *Gui) handleGuiEvent(guiEvent GuiEvent) {
 		}
 
 	case LogClicked:
-		err := open.Open(filepath.Join(gui.Config.ConfigDir, "logs", "systray.log"))
+		logDirPath := filepath.Join(gui.Config.ConfigDir, logger.LogDir)
+		logFilename := logger.LatestFilename(logDirPath, logger.Systray)
+		err := open.Open(filepath.Join(logDirPath, logFilename))
 		if err != nil {
 			log.Warnf("opening systray log: %v", err)
 		}


### PR DESCRIPTION
Latest version with logrotate seems to have broken the systray buttons for fetching logs, as they're no longer static file names but suffixed with a date. We fix this by introducing a method for getting the latest log, sorted by date.

It appears that the helper has its own path for logs rather than using the user config directory like the agent and systray. Not sure if it's intentional.

Also some other minor fixes, see the individual commits.