### PR TITLE
Redirect user to Console on successfull login

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-golang 1.23.3
+golang 1.23.6
 protoc 23.4
 protoc-gen-go 1.31.0
 protoc-gen-go-grpc 1.3.0

--- a/internal/device-agent/auth/azure.go
+++ b/internal/device-agent/auth/azure.go
@@ -63,10 +63,8 @@ func handleRedirectAzure(state string, conf oauth2.Config, codeVerifier *codever
 			return
 		}
 
-		msg := `Successfully authenticated 👌 Close me pls
-		<p style="text-align: center"><a href="https://console.nav.cloud.nais.io">Go to NAIS Console</a></p>
-		`
-		successfulResponse(w, msg, r.Header.Get("user-agent"))
+		http.Redirect(w, r, "https://console.nav.cloud.nais.io/?naisdevice=1", http.StatusSeeOther)
+
 		authFlowChan <- &authFlowResponse{Tokens: &Tokens{Token: t}, err: nil}
 	}
 }

--- a/internal/device-agent/auth/google.go
+++ b/internal/device-agent/auth/google.go
@@ -8,7 +8,9 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/lestrrat-go/jwx/jwt"
 	codeverifier "github.com/nirasan/go-oauth-pkce-code-verifier"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 )
 
@@ -73,8 +75,51 @@ func handleRedirectGoogle(state, redirectURI string, codeVerifier *codeverifier.
 			return
 		}
 
-		successfulResponse(w, "Successfully authenticated 👌 Close me pls", r.Header.Get("user-agent"))
+		ret, err := consoleURL(ctx, exchangeResponse.IDToken, "connected")
+		if err != nil {
+			logrus.Println("Failed to get console	URL: " + err.Error())
+			successfulResponse(w, "Successfully authenticated 👌 Close me pls", r.Header.Get("user-agent"))
+		} else {
+			http.Redirect(w, r, ret, http.StatusSeeOther)
+		}
+
 		tokens := &Tokens{Token: exchangeResponse.Token, IDToken: exchangeResponse.IDToken}
 		authFlowChan <- &authFlowResponse{Tokens: tokens, err: nil}
 	}
+}
+
+func consoleURL(ctx context.Context, idToken, state string) (string, error) {
+	// Parse id token to get domain
+	t, err := jwt.ParseString(idToken)
+	if err != nil {
+		return "", err
+	}
+	hd, _ := t.Get("hd")
+	domain, _ := hd.(string)
+
+	if domain == "" {
+		return "", fmt.Errorf("could not find domain in id token")
+	}
+
+	url := fmt.Sprintf("https://storage.googleapis.com/nais-tenant-data/%s.json", domain)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	d := struct {
+		ConsoleURL string `json:"consoleUrl"`
+	}{}
+	err = json.NewDecoder(resp.Body).Decode(&d)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("https://%s?naisdevice=%s", d.ConsoleURL, state), nil
 }


### PR DESCRIPTION
It will fall back to kek when we cannot decide on correct url

Some changes should be made to Console to show some information to the user when the `?naisdevice=connected` query parameter is provided before merging this