### PR TITLE
fix: use valid fallback version when no changelog is detected

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -102,7 +102,7 @@ jobs:
             ext: pkg
     runs-on: ${{ matrix.platform.runner }}
     env:
-      VERSION: ${{ needs.release-info.outputs.version || 'none' }} # Allow builds to continue with no version, it won't release.
+      VERSION: ${{ needs.release-info.outputs.version || 'v0.0.0' }} # Fallback to a valid version so packaging works even without a changelog. The release job gates on a real version.
       GOOS: ${{ matrix.platform.goos }}
       GOARCH: ${{ matrix.arch }}
       GOTAGS: ${{ matrix.gotags }}


### PR DESCRIPTION
## Summary

- When there are no conventional commits since the last release, git-cliff produces no version and CI fell back to `'none'`, which is not valid semver and caused packaging tasks to fail.
- Changed the fallback from `'none'` to `'v0.0.0'` so packaging (deb, pkg, NSIS) succeeds in CI even without a changelog.
- The release job already gates on a real version (`needs.release-info.outputs.version != ''`), so `v0.0.0` will never be released.