### PR TITLE
build: use release filename vars in package-manager templates

### DIFF
--- a/.github/workflows/templates/naisdevice-tenant.json
+++ b/.github/workflows/templates/naisdevice-tenant.json
@@ -2,7 +2,7 @@
   "version": "$VERSION",
   "architecture": {
     "64bit": {
-      "url": "$NAISDEVICE_TENANT_WINDOWS_AMD64_URL",
+      "url": "https://github.com/nais/device/releases/download/$version/$NAISDEVICE_TENANT_WINDOWS_AMD64_FILENAME",
       "hash": "$NAISDEVICE_TENANT_WINDOWS_AMD64_HASH_BASE16",
       "installer": {
         "script": [
@@ -21,7 +21,7 @@
       ]
     },
     "arm64": {
-      "url": "$NAISDEVICE_TENANT_WINDOWS_ARM64_URL",
+      "url": "https://github.com/nais/device/releases/download/$version/$NAISDEVICE_TENANT_WINDOWS_ARM64_FILENAME",
       "hash": "$NAISDEVICE_TENANT_WINDOWS_ARM64_HASH_BASE16",
       "installer": {
         "script": [

--- a/.github/workflows/templates/naisdevice-tenant.rb
+++ b/.github/workflows/templates/naisdevice-tenant.rb
@@ -11,12 +11,12 @@ cask "naisdevice-tenant" do
   ]
 
   if Hardware::CPU.intel?
-    url "$NAISDEVICE_TENANT_MACOS_AMD64_URL", verified: "github.com/nais/device/"
+    url "https://github.com/nais/device/releases/download/#{version}/$NAISDEVICE_TENANT_MACOS_AMD64_FILENAME", verified: "github.com/nais/device/"
     sha256 "$NAISDEVICE_TENANT_MACOS_AMD64_HASH_BASE16"
     pkg "naisdevice-tenant_macos_amd64.pkg"
   end
   if Hardware::CPU.arm?
-    url "$NAISDEVICE_TENANT_MACOS_ARM64_URL", verified: "github.com/nais/device/"
+    url "https://github.com/nais/device/releases/download/#{version}/$NAISDEVICE_TENANT_MACOS_ARM64_FILENAME", verified: "github.com/nais/device/"
     sha256 "$NAISDEVICE_TENANT_MACOS_ARM64_HASH_BASE16"
     pkg "naisdevice-tenant_macos_arm64.pkg"
   end

--- a/.github/workflows/templates/naisdevice.json
+++ b/.github/workflows/templates/naisdevice.json
@@ -2,7 +2,7 @@
   "version": "$VERSION",
   "architecture": {
     "64bit": {
-      "url": "$NAISDEVICE_WINDOWS_AMD64_URL",
+      "url": "https://github.com/nais/device/releases/download/$version/$NAISDEVICE_WINDOWS_AMD64_FILENAME",
       "hash": "$NAISDEVICE_WINDOWS_AMD64_HASH_BASE16",
       "installer": {
         "script": [
@@ -21,7 +21,7 @@
       ]
     },
     "arm64": {
-      "url": "$NAISDEVICE_WINDOWS_ARM64_URL",
+      "url": "https://github.com/nais/device/releases/download/$version/$NAISDEVICE_WINDOWS_ARM64_FILENAME",
       "hash": "$NAISDEVICE_WINDOWS_ARM64_HASH_BASE16",
       "installer": {
         "script": [

--- a/.github/workflows/templates/naisdevice.rb
+++ b/.github/workflows/templates/naisdevice.rb
@@ -11,12 +11,12 @@ cask "naisdevice" do
   ]
 
   if Hardware::CPU.intel?
-    url "$NAISDEVICE_MACOS_AMD64_URL", verified: "github.com/nais/device/"
+    url "https://github.com/nais/device/releases/download/#{version}/$NAISDEVICE_MACOS_AMD64_FILENAME", verified: "github.com/nais/device/"
     sha256 "$NAISDEVICE_MACOS_AMD64_HASH_BASE16"
     pkg "naisdevice_macos_amd64.pkg"
   end
   if Hardware::CPU.arm?
-    url "$NAISDEVICE_MACOS_ARM64_URL", verified: "github.com/nais/device/"
+    url "https://github.com/nais/device/releases/download/#{version}/$NAISDEVICE_MACOS_ARM64_FILENAME", verified: "github.com/nais/device/"
     sha256 "$NAISDEVICE_MACOS_ARM64_HASH_BASE16"
     pkg "naisdevice_macos_arm64.pkg"
   end

--- a/mise/tasks/ci/prepare-template-vars.sh
+++ b/mise/tasks/ci/prepare-template-vars.sh
@@ -31,9 +31,7 @@ while read -r hash file; do
 	hash16=${hash^^}
 	hash32=$(basenc --base16 -d <<<"${hash16}" | basenc --base32)
 
-	url="https://github.com/nais/device/releases/download/$VERSION/$basename"
-
 	echo "${key}_HASH_BASE16=${hash16}"
 	echo "${key}_HASH_BASE32=${hash32}"
-	echo "${key}_URL=$url"
+	echo "${key}_FILENAME=${basename}"
 done <"$checksums_txt"


### PR DESCRIPTION
## Summary
- switch Homebrew and Scoop templates to build release URLs from version plus generated filename vars instead of hard-coded names
- replace generated `*_URL` vars with `*_FILENAME` vars in `ci:prepare-template-vars`
- keep SHA256 checks in templates while making artifact naming changes centrally driven by release metadata