### PR TITLE
fix: force-kill naisdevice-helper.exe during installer upgrade

### DIFF
--- a/assets/windows/naisdevice.nsi
+++ b/assets/windows/naisdevice.nsi
@@ -316,6 +316,13 @@ Function ${prefix}_StopInstances_Step
     !insertmacro _Log "Attempt to stop running processes"
     Call ${prefix}CloseRunningInstances
 
+    ; Force-kill the helper if it's still running after graceful close
+    ${nsProcess::FindProcess} "naisdevice-helper.exe" $0
+    ${If} $0 = 0
+        !insertmacro _Log "naisdevice-helper.exe still running, force killing"
+        ${nsProcess::KillProcess} "naisdevice-helper.exe" $0
+    ${EndIf}
+
     Call ${prefix}CountRunningInstances
     Pop $0
     ${If} $0 = 0


### PR DESCRIPTION
The graceful CloseProcess signal may not stop the helper service
reliably. After the graceful attempt, check if the helper is still
running and force-kill it with TerminateProcess to ensure the
installer can replace the binary.
