### PR TITLE
upkeep: verified parameter is deprecated

### DIFF
--- a/.github/workflows/templates/naisdevice-tenant.rb
+++ b/.github/workflows/templates/naisdevice-tenant.rb
@@ -11,12 +11,12 @@ cask "naisdevice-tenant" do
   ]
 
   if Hardware::CPU.intel?
-    url "https://github.com/nais/device/releases/download/#{version}/$NAISDEVICE_TENANT_MACOS_AMD64_FILENAME", verified: "github.com/nais/device/"
+    url "https://github.com/nais/device/releases/download/#{version}/$NAISDEVICE_TENANT_MACOS_AMD64_FILENAME"
     sha256 "$NAISDEVICE_TENANT_MACOS_AMD64_HASH_BASE16"
     pkg "naisdevice-tenant_macos_amd64.pkg"
   end
   if Hardware::CPU.arm?
-    url "https://github.com/nais/device/releases/download/#{version}/$NAISDEVICE_TENANT_MACOS_ARM64_FILENAME", verified: "github.com/nais/device/"
+    url "https://github.com/nais/device/releases/download/#{version}/$NAISDEVICE_TENANT_MACOS_ARM64_FILENAME"
     sha256 "$NAISDEVICE_TENANT_MACOS_ARM64_HASH_BASE16"
     pkg "naisdevice-tenant_macos_arm64.pkg"
   end

--- a/.github/workflows/templates/naisdevice.rb
+++ b/.github/workflows/templates/naisdevice.rb
@@ -11,12 +11,12 @@ cask "naisdevice" do
   ]
 
   if Hardware::CPU.intel?
-    url "https://github.com/nais/device/releases/download/#{version}/$NAISDEVICE_MACOS_AMD64_FILENAME", verified: "github.com/nais/device/"
+    url "https://github.com/nais/device/releases/download/#{version}/$NAISDEVICE_MACOS_AMD64_FILENAME"
     sha256 "$NAISDEVICE_MACOS_AMD64_HASH_BASE16"
     pkg "naisdevice_macos_amd64.pkg"
   end
   if Hardware::CPU.arm?
-    url "https://github.com/nais/device/releases/download/#{version}/$NAISDEVICE_MACOS_ARM64_FILENAME", verified: "github.com/nais/device/"
+    url "https://github.com/nais/device/releases/download/#{version}/$NAISDEVICE_MACOS_ARM64_FILENAME"
     sha256 "$NAISDEVICE_MACOS_ARM64_HASH_BASE16"
     pkg "naisdevice_macos_arm64.pkg"
   end


### PR DESCRIPTION
Med nyeste Homebrew får man følgende advarsel:

> Warning: Calling the `verified` parameter in the `url` stanza is deprecated! Use the default URL verification behaviour instead.
> Please report this issue to the nais/homebrew-tap tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
>   /opt/homebrew/Library/Taps/nais/homebrew-tap/Casks/naisdevice.rb:19

> Warning: Calling the `verified` parameter in the `url` stanza is deprecated! Use the default URL verification behaviour instead.
> Please report this issue to the nais/homebrew-tap tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
>   /opt/homebrew/Library/Taps/nais/homebrew-tap/Casks/naisdevice-tenant.rb:19